### PR TITLE
autocorrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check positional argument style before Faker 2.
 Auto-correction to keyword argument style on Faker 2.
 
 ```console
-% rubocop --require rubocop-faker --only Faker/DeprecatedArguments --auto-correct
+% rubocop --require rubocop-faker --only Faker/DeprecatedArguments --autocorrect
 ```
 
 ### RuboCop configuration file


### PR DESCRIPTION
update readme, since apparently rubocop deprecated the `--auto-correct` option in favor of `--autocorrect` or `-a`

```
rubocop -h
```

![image](https://user-images.githubusercontent.com/918804/207992335-3b3caaff-cb16-4c1d-bfb5-9518a0aebe80.png)
